### PR TITLE
feat: enable setting search_path

### DIFF
--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -165,6 +165,7 @@ pub struct Config {
     pub(crate) target_session_attrs: TargetSessionAttrs,
     pub(crate) channel_binding: ChannelBinding,
     pub(crate) pgbouncer_mode: bool,
+    pub(crate) search_path: Option<String>,
 }
 
 impl Default for Config {
@@ -196,6 +197,7 @@ impl Config {
             target_session_attrs: TargetSessionAttrs::Any,
             channel_binding: ChannelBinding::Prefer,
             pgbouncer_mode: false,
+            search_path: None,
         }
     }
 
@@ -439,6 +441,17 @@ impl Config {
     /// Gets the pgBouncer mode status.
     pub fn get_pgbouncer_mode(&self) -> bool {
         self.pgbouncer_mode
+    }
+
+    /// Sets the search_path.
+    pub fn search_path(&mut self, search_path: String) -> &mut Config {
+        self.search_path = Some(search_path);
+        self
+    }
+
+    /// Gets the search path.
+    pub fn get_search_path(&self) -> Option<&String> {
+        self.search_path.as_ref()
     }
 
     fn param(&mut self, key: &str, value: &str) -> Result<(), Error> {

--- a/tokio-postgres/src/connect_raw.rs
+++ b/tokio-postgres/src/connect_raw.rs
@@ -131,6 +131,10 @@ where
         params.push(("application_name", &**application_name));
     }
 
+    if let Some(schema_path) = &config.search_path {
+        params.push(("search_path", &**schema_path));
+    }
+
     let mut buf = BytesMut::new();
     frontend::startup_message(params, &mut buf).map_err(Error::encode)?;
 


### PR DESCRIPTION
## Overview

- Enables setting the search_path without issuing a query to the database. The search_path is set as part of the client-side options when connecting to the database. This saves a roundtrip when connecting.

See https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-SEARCH-PATH for further documentation.